### PR TITLE
Removed spurious dependency from sugar-build

### DIFF
--- a/config/deps/sugar-runtime.json
+++ b/config/deps/sugar-runtime.json
@@ -82,11 +82,6 @@
         "name": "gtksource typelib"
     }, 
     {
-        "check": "import gtksourceview2", 
-        "checker": "python", 
-        "name": "gtksourceview2 python"
-    }, 
-    {
         "check": "import hippo", 
         "checker": "python", 
         "name": "hippo python"

--- a/config/packages/deps.json
+++ b/config/packages/deps.json
@@ -501,17 +501,6 @@
             "gir1.2-gtksource-3.0"
         ]
     }, 
-    "gtksourceview2 python": {
-        "debian": [
-            "python-gtksourceview2"
-        ], 
-        "fedora": [
-            "pygtksourceview"
-        ], 
-        "ubuntu": [
-            "python-gtksourceview2"
-        ]
-    }, 
     "hippo python": {
         "debian": [
             "python-hippocanvas"


### PR DESCRIPTION
There's a false dependency on pygtksourceview2 which is obviated by using GObject Introspection. Installing it via the package suggestion in the build system caused me not to get the proper gtksourceview lib, which caused the problems I had with `make run`.
