### PR TITLE
Gtk version mismatch

### DIFF
--- a/config/deps/sugar-build.json
+++ b/config/deps/sugar-build.json
@@ -10,7 +10,7 @@
         "name": "atk-bridge"
     }, 
     {
-        "check": "from gi.repository import Atspi", 
+        "check": "import gi; gi.require_version('Gtk', '3.0'); from gi.repository import Gtk; from gi.repository import Atspi", 
         "checker": "python", 
         "name": "atspi typelib"
     }, 

--- a/config/deps/sugar-runtime.json
+++ b/config/deps/sugar-runtime.json
@@ -21,7 +21,7 @@
         "name": "cairo foreign"
     }, 
     {
-        "check": "from gi.repository import cairo", 
+        "check": "import gi; gi.require_version('Gtk', '3.0'); from gi.repository import Gtk; from gi.repository import cairo", 
         "checker": "python", 
         "name": "cairo typelib"
     }, 
@@ -46,7 +46,7 @@
         "name": "espeak"
     }, 
     {
-        "check": "from gi.repository import EvinceDocument", 
+        "check": "import gi; gi.require_version('Gtk', '3.0'); from gi.repository import Gtk; from gi.repository import EvinceDocument", 
         "checker": "python", 
         "name": "evince typelib"
     }, 
@@ -56,7 +56,7 @@
         "name": "gconf python"
     }, 
     {
-        "check": "from gi.repository import GConf", 
+        "check": "import gi; gi.require_version('Gtk', '3.0'); from gi.repository import Gtk; from gi.repository import GConf", 
         "checker": "python", 
         "name": "gconf typelib"
     }, 
@@ -154,7 +154,7 @@
         "name": "wnck python"
     }, 
     {
-        "check": "from gi.repository import Wnck", 
+        "check": "import gi; gi.require_version('Gtk', '3.0'); from gi.repository import Gtk; from gi.repository import Wnck", 
         "checker": "python", 
         "name": "wnck typelib"
     }, 


### PR DESCRIPTION
When someone has a Gtk2 version of a gobject-introspection-provided dep, it can be falsely detected as satisfying the dependency. This imports Gtk before gi.repository imports to make sure there is no Gtk version mismatch.
