### PR TITLE
Updating build system should reload config

### DIFF
--- a/commands/pull
+++ b/commands/pull
@@ -14,19 +14,21 @@ parser.add_argument("module", nargs="?", help="name of the module to pull")
 parser.add_argument("--revisions", help="json dict with the revisions to pull")
 args = parser.parse_args()
 
-common.setup(log_name="pull")
 
 if args.module:
+    common.setup(log_name="pull")
     if not build.pull_one(args.module):
         sys.exit(1)
 else:
+    if not common.is_buildbot():
+        print("\n= Updating build system =\n")
+        print("* Pulling sugar-build")
+        command.run(["git", "pull", "--ff-only"])
+    common.setup(log_name="pull")
+
     revisions = {}
     if args.revisions:
         revisions = json.loads(args.revisions)
 
     if not build.pull(revisions):
         sys.exit(1)
-
-    if not common.is_buildbot():
-        print("* Pulling sugar-build")
-        command.run(["git", "pull", "--ff-only"])


### PR DESCRIPTION
In cases where new dependencies or modules are added, a single `make pull` should be all that's necessary. Currently, it takes two `make pull`s to get the most up to date set of repos.

This patch updates the build system first, and then reloads the config, such that new dependencies and modules are picked up prior to pulling anything else.
