### PR TITLE
Use packaged nodejs for fedora-19

### DIFF
--- a/config/deps/sugar-build.json
+++ b/config/deps/sugar-build.json
@@ -30,6 +30,11 @@
         "name": "gail gtkmodule"
     }, 
     {
+        "check": "node",
+        "checker": "binary",
+        "name": "node"
+    },
+    {
         "check": "pep8", 
         "checker": "binary", 
         "name": "pep8"

--- a/config/modules/system.json
+++ b/config/modules/system.json
@@ -167,6 +167,7 @@
         "repo": "git://github.com/dnarvaez/gwebsockets"
     }, 
     {
+        "if": "distro != 'fedora-19'",
         "name": "node", 
         "no_libdir": true, 
         "out-of-source": false, 

--- a/config/packages/deps.json
+++ b/config/packages/deps.json
@@ -728,6 +728,11 @@
             "network-manager"
         ]
     }, 
+    "node": {
+        "fedora": [
+            "nodejs"
+        ]
+    },
     "org.freedesktop.Telepathy.AccountManager": {
         "debian": [
             "telepathy-mission-control-5"


### PR DESCRIPTION
The version of nodejs in Fedora 19 is the same as the one that we want.

I've added it to build deps, and tested by running an activity built from the sugar-html-template.
