### PR TITLE
Npm fixes

### DIFF
--- a/config/deps/sugar-build.json
+++ b/config/deps/sugar-build.json
@@ -36,6 +36,12 @@
         "name": "node"
     },
     {
+        "check": "npm",
+        "checker": "binary",
+        "if": "distro == 'fedora-19'", 
+        "name": "npm"
+    },
+    {
         "check": "pep8", 
         "checker": "binary", 
         "name": "pep8"

--- a/config/packages/deps.json
+++ b/config/packages/deps.json
@@ -733,6 +733,11 @@
             "nodejs"
         ]
     },
+    "npm": {
+        "fedora": [
+            "npm"
+        ]
+    },
     "org.freedesktop.Telepathy.AccountManager": {
         "debian": [
             "telepathy-mission-control-5"

--- a/devbot/build.py
+++ b/devbot/build.py
@@ -166,7 +166,7 @@ _builders["volo"] = _build_volo
 
 
 def _build_npm(module, log):
-    command.run(["npm", "install", "-g"], log)
+    command.run(["npm", "install", "-g", "--prefix", config.install_dir], log)
 
 _builders["npm"] = _build_npm
 


### PR DESCRIPTION
- use the system npm where available (fedora 19)
- when devbot does an `npm install`, add prefix flag and install it under `install/`
