### PR TITLE
Added jshint tests

### DIFF
--- a/config/modules/sugar.json
+++ b/config/modules/sugar.json
@@ -40,14 +40,17 @@
         "repo": "git://github.com/sugarlabs/sugar-runner.git"
     }, 
     {
+        "has_checks": true, 
         "name": "sugar-html-template", 
         "repo": "git://github.com/sugarlabs/sugar-html-template.git"
     }, 
     {
+        "has_checks": true, 
         "name": "sugar-html-core", 
         "repo": "git://github.com/sugarlabs/sugar-html-core.git"
     }, 
     {
+        "has_checks": true, 
         "name": "sugar-html-graphics", 
         "repo": "git://github.com/sugarlabs/sugar-html-graphics.git"
     }

--- a/config/modules/system.json
+++ b/config/modules/system.json
@@ -179,5 +179,11 @@
         "out-of-source": false, 
         "repo": "git://github.com/volojs/volo.git", 
         "tag": "v0.2.10"
+    },
+    {
+        "name": "jshint",
+        "out-of-source": false,
+        "repo": "git://github.com/jshint/jshint.git",
+        "tag": "2.0.1"
     }
 ]


### PR DESCRIPTION
- also enabled tests for all js modules
- added jshint as a dep

This is a rough first attempt at adding jshint tests to `make check`. One of the problems - sugar-html-template generates errors, as require.js isn't jshint friendly.

One thought I had was to not check if a file's path, relative to the toplevel of the module, contained `/lib/`. Does that seem like a valid check? Can we expect/require all activity/module authors to keep their js libs in lib/?

Thanks for the help!
