### PR TITLE
Ubuntu and Debian need to pull pep8 from github

### DIFF
--- a/config/modules/system.json
+++ b/config/modules/system.json
@@ -185,5 +185,12 @@
         "out-of-source": false,
         "repo": "git://github.com/jshint/jshint.git",
         "tag": "2.0.1"
+    },
+    {
+        "if": "not distro.startswith('fedora')", 
+        "name": "pep8",
+        "out-of-source": false,
+        "repo": "git://github.com/jcrocholl/pep8.git",
+        "tag": "1.4.5"
     }
 ]


### PR DESCRIPTION
Should satisfy buildbot now - pulls 1.4.5
