### PR TITLE
Add python-mock dependency

### DIFF
--- a/build/root.json
+++ b/build/root.json
@@ -53,6 +53,7 @@
             "dbus-python",
             "python-telepathy",
             "python-dateutil",
+            "python-mock",
             "gtksourceview3",
             "dconf",
             "gsettings-desktop-schemas",


### PR DESCRIPTION
We need to add Python mock library to run new tests.
