### PR TITLE
Add mobile-broadband-provider-info dependency

### DIFF
--- a/build/root.json
+++ b/build/root.json
@@ -67,6 +67,7 @@
             "gstreamer-plugins-espeak",
             "telepathy-salut",
             "telepathy-gabble",
+            "mobile-broadband-provider-info",
             "gnome-themes-standard",
             "xorg-x11-drv-evdev",
             "xorg-x11-drv-modesetting",


### PR DESCRIPTION
It adds [mobile-broadband-provider-info package](https://apps.fedoraproject.org/packages/mobile-broadband-provider-info/) root.json sugar group. This package includes the file /usr/share/mobile-broadband-provider-info/serviceproviders.xml needed by 3G database support.
