### PR TITLE
karma command launches sugar-runner through run.run()

### DIFF
--- a/build/commands/broot/karma
+++ b/build/commands/broot/karma
@@ -6,7 +6,7 @@ import os
 import common
 
 from osbuild import config
-from osbuild import command
+from osbuild import run
 
 common.setup()
 
@@ -28,4 +28,4 @@ else:
 os.environ["SUGAR_RUN_TEST"] = "/usr/bin/karma --browsers %s %s" % \
     (os.path.join(config.bin_dir, "sugar-web-test"), karma_args)
 
-command.run("sugar-runner", watch_log=watch_log)
+run.run("sugar-runner", watch_log=watch_log)


### PR DESCRIPTION
this is needed in order to karma command gets the
screen resolution from prefs.json at the time of
launching sugar-runner

_WARNING!!_: https://github.com/dnarvaez/osbuild/pull/4 needs to be mergerd first!!
