### PR TITLE
Fix prebuilt broken link

### DIFF
--- a/build/root.json
+++ b/build/root.json
@@ -143,7 +143,7 @@
     },
     "prebuilt": {
         "name": "master",
-        "url": "http://sugarlabs.org/~buildbot/broot/"
+        "url": "http://sunjammer.sugarlabs.org/~buildbot/broot/"
     },
     "shell_path": "/home/broot/sugar-build",
     "stamp": "11",


### PR DESCRIPTION
sugarlabs.org is pointing to freedom. Currently, the broot images are hosted on sunjammer.