### PR TITLE
Report failure to create lock file

### DIFF
--- a/osbuild
+++ b/osbuild
@@ -403,8 +403,9 @@ def run_command(command, args):
 
 
 def check_lock():
+    lock_file = get_lock_file()
     try:
-        fcntl.lockf(get_lock_file(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.lockf(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except IOError:
         return False
 


### PR DESCRIPTION
Several users have reported "Another osbuild instance is running" when
the lock file cannot be created.

Move the create of the lock file out of the exception handler, so that a
full exception is reported.
