### PR TITLE
Update root.json

### DIFF
--- a/build/root.json
+++ b/build/root.json
@@ -41,7 +41,7 @@
             "gcc",
             "python-devel",
             "bzip2",
-            "npm",
+            "nodejs",
             "xz",
             "sudo",
             "automake",


### PR DESCRIPTION
'npm' caused a fatal error on Fedora 24 but replacing it with 'nodejs' seems to work.