### PR TITLE
Fixed #42; Removed unneeded dependency

### DIFF
--- a/build/root.json
+++ b/build/root.json
@@ -90,7 +90,6 @@
             "xorg-x11-drv-modesetting",
             "xorg-x11-drv-fbdev",
             "xorg-x11-drv-vesa",
-            "xorg-x11-drv-vmmouse",
             "xorg-x11-drv-intel",
             "xorg-x11-drv-vmware",
             "xorg-x11-drv-synaptics",


### PR DESCRIPTION
I have tested building sugar without `xorg-x11-drv-vmmouse` dependency in `root.json` on Debian and Fedora. It does work as it should. Below there is a build log (from Debian): 

```
tymon@tymonhost:~/sugar-build$ ./osbuild build

$ sudo broot run osbuild build

= Building =

* Building automake
* Building gwebsockets
* Building sugar-docs
* Building sugar-base
* Building sugar-toolkit
* Building sugar-toolkit-gtk3
* Building sugar
* Building sugar-artwork
* Building sugar-datastore
* Building sugar-runner
* Building sugar-web
* Building sugar-web-test
* Building sugar-web-template
* Building docker
* Building browse
* Building write
* Building chat
* Building read
* Building log
* Building terminal
* Building pippy
* Building imageviewer
* Building jukebox
* Building turtleart
* Building clock-web
* Building gtd-activity
```